### PR TITLE
forgot to commit this whoops: Renamed PluginInfo.cs fields and split hooks into seperate file

### DIFF
--- a/src/Plugin/src/Hooks.cs
+++ b/src/Plugin/src/Hooks.cs
@@ -1,13 +1,13 @@
 namespace H3VRMod
 {
-    public static class Hooks
+    public class Hooks
     {
-        public static void Hook()
+        public void Hook()
         {
             
         }
 
-        public static void Unhook()
+        public void Unhook()
         {
             
         }

--- a/src/Plugin/src/Hooks.cs
+++ b/src/Plugin/src/Hooks.cs
@@ -1,0 +1,15 @@
+namespace H3VRMod
+{
+    public static class Hooks
+    {
+        public static void Hook()
+        {
+            
+        }
+
+        public static void Unhook()
+        {
+            
+        }
+    }
+}

--- a/src/Plugin/src/Plugin.cs
+++ b/src/Plugin/src/Plugin.cs
@@ -7,8 +7,11 @@ namespace H3VRMod
 	[BepInProcess("h3vr.exe")]
 	public class Plugin : BaseUnityPlugin
 	{
+		internal Hooks Hooks;
+	
 		public Plugin()
 		{
+			Hooks = new Hooks();
 			Hooks.Hook();
 		}
 

--- a/src/Plugin/src/Plugin.cs
+++ b/src/Plugin/src/Plugin.cs
@@ -2,7 +2,7 @@
 
 namespace H3VRMod
 {
-	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+	[BepInPlugin(PluginInfo.GUID, PluginInfo.NAME, PluginInfo.VERSION)]
 	[BepInProcess("h3vr.exe")]
 	public class Plugin : BaseUnityPlugin
 	{

--- a/src/Plugin/src/Plugin.cs
+++ b/src/Plugin/src/Plugin.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx;
+﻿using System;
+using BepInEx;
 
 namespace H3VRMod
 {
@@ -8,22 +9,22 @@ namespace H3VRMod
 	{
 		public Plugin()
 		{
-			Hook();
+			Hooks.Hook();
+		}
+
+		private void Awake()
+		{
+			
+		}
+
+		private void Update()
+		{
+			
 		}
 
 		private void OnDestroy()
 		{
-			Unhook();
-		}
-
-		private void Hook()
-		{
-
-		}
-
-		private void Unhook()
-		{
-
+			Hooks.Unhook();
 		}
 	}
 }

--- a/src/Plugin/src/PluginInfo.cs
+++ b/src/Plugin/src/PluginInfo.cs
@@ -2,8 +2,8 @@ namespace H3VRMod
 {
     internal static class PluginInfo
     {
-        internal const string PLUGIN_NAME = "Example H3VR Mod";
-        internal const string PLUGIN_GUID = "com.yourname.h3vrmod";
-        internal const string PLUGIN_VERSION = "1.0.0";
+        internal const string NAME = "Example H3VR Mod";
+        internal const string GUID = "com.yourname.h3vrmod";
+        internal const string VERSION = "1.0.0";
     }
 }


### PR DESCRIPTION
1. There really isn't a use to having `PLUGIN_` as a prefix when the class is already `PluginInfo`
2. In many H3VR Mods, hooks aren't used at all, having it as a separate file keeps things tidy.
	- I am not sure if this should be static or not	